### PR TITLE
fix: Sign in reference

### DIFF
--- a/fimarket/app/components/footer.jsx
+++ b/fimarket/app/components/footer.jsx
@@ -40,7 +40,7 @@ return (
             <Link href="/" color="inherit" underline="hover" display="block">Main Menu</Link>        </Grid>
         <Grid item xs={12} md={2}>
             <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>Account</Typography>
-            <Link href="/SignIn" color="inherit" underline="hover" display="block">Sing in</Link>
+            <Link href="/signIn" color="inherit" underline="hover" display="block">Sing in</Link>
         </Grid>
         <Grid item xs={12} md={2}>
             <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>Apps</Typography>


### PR DESCRIPTION
This merge will impact footer.jsx it only corrects a spelling mistake that allows us to visit the Sign In page by clicking on its respective footer link
I updated the link to Sign In so it redirects correctly