### PR TITLE
fix(sign-in):now the user can perform the sign in procedure

### DIFF
--- a/fimarket/app/signIn/page.jsx
+++ b/fimarket/app/signIn/page.jsx
@@ -5,6 +5,7 @@ import { TextField, Button, Typography, Container, Box, Paper } from "@mui/mater
 import GoogleIcon from '@mui/icons-material/Google';
 import FacebookIcon from '@mui/icons-material/Facebook';
 import { useRouter } from "next/navigation"; 
+import { userAgentFromString } from 'next/server';
 
 const SignIn = ({ onSignIn }) => { // Receive onSignIn as a prop
     const [email, setEmail] = useState('');
@@ -14,21 +15,32 @@ const SignIn = ({ onSignIn }) => { // Receive onSignIn as a prop
     const handleSubmit = (e) => {
         // Prevent the default form submission behavior
         e.preventDefault();
+
+        /*---------------------SIGN IN LOGIC--------------------------*/
+
+        const users = JSON.parse(localStorage.getItem('users')) || [];
+
+        const foundUser = users.find(u => u.emailU === email && u.passwordU === password);
+
+
+        if (foundUser) {
+            localStorage.setItem("isAuthenticated", "true");
+            window.dispatchEvent(new Event("storage"));
+            router.push("/");
+        } else {
+            alert("Incorrect username or password :(. Please, try again.");
+        }    
     
-        // Set the authentication status to true in localStorage
-        localStorage.setItem("isAuthenticated", "true");
-    
-        // Dispatch a storage event to notify other components (like AppBarGlobal)
-        // that the authentication status has changed
-        window.dispatchEvent(new Event("storage"));
-    
-        // Redirect the user to the home page after successful login
-        router.push("/");
+    /*-----------------------------------------------------------*/
+ 
     }
 
     const handleSU = () => {
         router.push("/signUp");
     };
+
+
+    
 
     return (
         <Box

--- a/fimarket/app/signUp/page.jsx
+++ b/fimarket/app/signUp/page.jsx
@@ -30,36 +30,54 @@ import FavoriteTwoToneIcon from '@mui/icons-material/FavoriteTwoTone';
 import AccessTimeTwoToneIcon from '@mui/icons-material/AccessTimeTwoTone';
 import HandymanTwoToneIcon from '@mui/icons-material/HandymanTwoTone';
 import TipsAndUpdatesTwoToneIcon from '@mui/icons-material/TipsAndUpdatesTwoTone';
-
+import { ContentCutOutlined } from '@mui/icons-material';
 
 
 const SignUp = ({ onSignUp }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const router = useRouter(); // Instantiating my class for the routes
+  const router = useRouter(); //function to redirect "Don't have an account? Sign Up"
+  const user = { emailU: email, passwordU: password };
+
 
   const handleSubmit = (e) => {
-    // Prevent the default form submission behavior
+    // Prevent the default form submission behavior.
     e.preventDefault();
+  
+    /*---------------------SIGN UP LOGIC--------------------------*/
+    let users = JSON.parse(localStorage.getItem('users')) || [];
+
+    users.push(user);
+
+    localStorage.setItem('users', JSON.stringify(users));
+
+    router.push("/");
+
+    console.log("Saved users on LocalStorage:", users);
+    /*-----------------------------------------------------------*/
+
 
     // Set the authentication status to true in localStorage
     localStorage.setItem("isAuthenticated", "true");
-    
+     
     // Dispatch a storage event to notify other components (like AppBarGlobal)
     // that the authentication status has changed
     window.dispatchEvent(new Event("storage"));
 
-    // Redirect the user to the home page after successful login
-    router.push("/");
-  }
+    //Looks for SignUp email and password.
+    console.log("Signup email:", email, "password:", password);
 
-  const handleSI = () => { // Function to signUp
+    };
+
+  const stringifiedPerson = localStorage.getItem('user') ;
+  const personAsObjectAgain = JSON.parse(stringifiedPerson );
+
+  const handleSI = () => { // "Don't have an account? Sign Up"
     router.push("/signIn");
   };
 
   return (
-    <Box
-        
+    <Box        
       sx={{
         minHeight: 'flex',
         p: 3,
@@ -249,6 +267,8 @@ const SignUp = ({ onSignUp }) => {
                     },
                   }}
                 />
+
+
                 <Button sx={{mt:6}} type="submit" variant='contained' color='secondary' fullWidth>
                   Sign Up
                 </Button>


### PR DESCRIPTION
What?
I fixed the sign-in page for user authentication using their previously created email and password.

Why?
So the user can access the favorites page and save their apps.

How?
On previous versions, the page itself did not have a sign up function. One of the main objectives of the page was that the user was able to save their favorite apps on the store. With the sign up function, on the upcoming versions this logic will be implemented.

Testing?
To verify that this function was set up correctly, some tests were done with different emails and passwords. These tests were verified with the help of the development web tools, watching the localStorage value.

Screenshots
![sign in2](https://github.com/user-attachments/assets/8f290a54-aa39-4e99-acdd-c6af82d81664)
![sign in1](https://github.com/user-attachments/assets/bd33c3f9-604c-4be1-a6d1-a1c4f028a031)



