### PR TITLE
hotfix(about): changed banner image

### DIFF
--- a/fimarket/app/about/page.jsx
+++ b/fimarket/app/about/page.jsx
@@ -21,7 +21,7 @@ export default function About() {
         }}>
             <Box sx={{
                 boxShadow: 3,
-                backgroundImage: "url('/header.png')",
+                backgroundImage: "url('/banner.jpg')",
                 backgroundSize: "cover",
                 height: "200px",
                 width: "100%",


### PR DESCRIPTION
## What?
Changed banner image on about page

## Why?
Previous image was not relevant. This change incorporates an image that is already being used on other pages

## How?
I changed the url line on the about page

## Testing?
I ran the app to verify that the change has been made

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/7f540f17-b791-4845-bf55-52e373741b7a)
After:
![image](https://github.com/user-attachments/assets/5454fb4a-1054-45d4-b015-986d70f7480b)