### PR TITLE
fix(sign-up): fix localstorage error

### DIFF
--- a/fimarket/app/signUp/page.jsx
+++ b/fimarket/app/signUp/page.jsx
@@ -69,8 +69,7 @@ const SignUp = ({ onSignUp }) => {
 
     };
 
-  const stringifiedPerson = localStorage.getItem('user') ;
-  const personAsObjectAgain = JSON.parse(stringifiedPerson );
+
 
   const handleSI = () => { // "Don't have an account? Sign Up"
     router.push("/signIn");


### PR DESCRIPTION
### What?
Fixed the localStorage is not defined error in the sign up page.

### Why?
To prevent errors during the execution of the sign up page.

### How?
There were two lines previously used for debugging. When I cleaned up unused constants, I mistakenly deleted those lines, leaving the function incomplete and with undeclared elements. I simply removed them.

### Testing?
To verify that this function was set up correctly, some tests were done with different emails and passwords. These tests were verified with the help of the development web tools, watching the localStorage value.

### Screenshots
![image](https://github.com/user-attachments/assets/7276cf38-e590-498c-858b-9309e6bca491)
