### PR TITLE
fix(sign-in): adding user authentication

### DIFF
--- a/fimarket/app/signIn/page.jsx
+++ b/fimarket/app/signIn/page.jsx
@@ -5,6 +5,7 @@ import { TextField, Button, Typography, Container, Box, Paper } from "@mui/mater
 import GoogleIcon from '@mui/icons-material/Google';
 import FacebookIcon from '@mui/icons-material/Facebook';
 import { useRouter } from "next/navigation"; 
+import { userAgentFromString } from 'next/server';
 
 const SignIn = ({ onSignIn }) => { // Receive onSignIn as a prop
     const [email, setEmail] = useState('');
@@ -14,21 +15,32 @@ const SignIn = ({ onSignIn }) => { // Receive onSignIn as a prop
     const handleSubmit = (e) => {
         // Prevent the default form submission behavior
         e.preventDefault();
+
+        /*---------------------SIGN IN LOGIC--------------------------*/
+
+        const users = JSON.parse(localStorage.getItem('users')) || [];
+
+        const foundUser = users.find(u => u.emailU === email && u.passwordU === password);
+
+
+        if (foundUser) {
+            localStorage.setItem("isAuthenticated", "true");
+            window.dispatchEvent(new Event("storage"));
+            router.push("/");
+        } else {
+            alert("Incorrect username or password :(. Please, try again.");
+        }    
     
-        // Set the authentication status to true in localStorage
-        localStorage.setItem("isAuthenticated", "true");
-    
-        // Dispatch a storage event to notify other components (like AppBarGlobal)
-        // that the authentication status has changed
-        window.dispatchEvent(new Event("storage"));
-    
-        // Redirect the user to the home page after successful login
-        router.push("/");
+    /*-----------------------------------------------------------*/
+ 
     }
 
     const handleSU = () => {
         router.push("/signUp");
     };
+
+
+    
 
     return (
         <Box


### PR DESCRIPTION
### What?
this is the logic implemented on the Project which will be used on upcoming versions. This can save multiple users with the previously registered data on the sign up page.

### Why?
One of the main objectives of the Project is that the user was able to sabe their favorite apps. With the login function, Every user Will have a "saved apps" tab and Will be different for each one.

### How?
The user was previously saved via the sign up page. On that step, the password and the email was saved on the localStorage variable, there's an array with the data of each user. On the login page, the data saved on this array is compared with the values entered on the email and password fields. If the values entered matches with one of the values saved, the user will login into the page.

### Testing?
To test this funcionality, the developer entered some set of credentials (email-password) on the signup page. Then, with the login page, this values were entered, attempting different combinations: a wrong password, a wrong email, and both incorrect. All of the test were successful and the page matched this credentials correctly.

### Screenshots
![sign in1](https://github.com/user-attachments/assets/1c8ab728-d506-4de6-95d5-4d54ea1e1a16)
![sign in2](https://github.com/user-attachments/assets/8b173eb4-a7c5-462c-82fb-0d0f55dcf73a)